### PR TITLE
Refactor OwnerDashboard layout & responsive styles

### DIFF
--- a/frontend/src/pages/HostelManagement/HostelAdmin.jsx
+++ b/frontend/src/pages/HostelManagement/HostelAdmin.jsx
@@ -3,6 +3,7 @@ import './HostelAdmin.css';
 
 const TABS = [
     { id: 'pending', label: '⏳ Pending Listings' },
+    { id: 'all', label: '📂 Manage All' },
     { id: 'reviews', label: '⭐ Reviews Moderation' },
     { id: 'reported', label: '🚩 Reported Listings' },
     { id: 'featured', label: '📌 Featured Listings' },
@@ -86,10 +87,18 @@ const HostelAdmin = () => {
         else flash(data.message || 'Failed', true);
     };
 
-    /* ---- Reported actions ---- */
+    /* ---- Reported / General actions ---- */
     const removeListing = async (id) => {
+        if (!window.confirm('Are you sure you want to permanently delete this listing?')) return;
+        
         const { ok, data } = await req(`${BASE}/hostel/${id}`, 'DELETE');
-        if (ok) { setReported(r => r.filter(x => x._id !== id)); setAllHostels(a => a.filter(x => x._id !== id)); flash('Listing removed.'); }
+        if (ok) { 
+            setReported(r => r.filter(x => x._id !== id)); 
+            setAllHostels(a => a.filter(x => x._id !== id)); 
+            setPending(p => p.filter(x => x._id !== id));
+            setFeatured(f => f.filter(x => x._id !== id));
+            flash('Listing removed.'); 
+        }
         else flash(data.message || 'Failed', true);
     };
     const dismissReport = async (id) => {
@@ -115,7 +124,7 @@ const HostelAdmin = () => {
     /* ---- Stat counts ---- */
     const stats = [
         { label: 'Pending', value: pending.length, color: '#f59e0b', icon: '⏳' },
-        { label: 'Reviews', value: reviews.length, color: '#8b5cf6', icon: '⭐' },
+        { label: 'Total', value: allHostels.length, color: '#3b82f6', icon: '📂' },
         { label: 'Reported', value: reported.length, color: '#ef4444', icon: '🚩' },
         { label: 'Featured', value: featured.length, color: '#10b981', icon: '📌' },
     ];
@@ -223,6 +232,50 @@ const HostelAdmin = () => {
                                             ))}
                                         </div>
                                     )}
+                            </div>
+                        {/* ===== MANAGE ALL LISTINGS ===== */}
+                        {activeTab === 'all' && (
+                            <div className="ha-section">
+                                <div className="ha-card-head">
+                                    <h3>System Listings</h3>
+                                    <span className="ha-count-pill">{allHostels.length} total hostels</span>
+                                </div>
+                                <div className="ha-table-wrapper">
+                                    <table className="ha-modern-table">
+                                        <thead>
+                                            <tr>
+                                                <th>Hostel</th>
+                                                <th>Owner</th>
+                                                <th>Status</th>
+                                                <th>Action</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {allHostels.map(h => (
+                                                <tr key={h._id}>
+                                                    <td>
+                                                        <div className="ha-user-cell">
+                                                            <img src={h.images?.[0] || h.image || ''} style={{ width: '40px', height: '40px', borderRadius: '4px', objectFit: 'cover' }} alt="" />
+                                                            <div>
+                                                                <strong>{h.name}</strong>
+                                                                <div style={{ fontSize: '0.8rem', color: '#64748b' }}>{h.location}</div>
+                                                            </div>
+                                                        </div>
+                                                    </td>
+                                                    <td>{h.owner?.name || h.owner?.username || '—'}</td>
+                                                    <td>
+                                                        <span className={`ha-count-pill ${h.status === 'approved' ? 'success' : h.status === 'pending' ? 'warning' : 'danger'}`}>
+                                                            {h.status || 'Pending'}
+                                                        </span>
+                                                    </td>
+                                                    <td>
+                                                        <button className="ha-btn-text danger" onClick={() => removeListing(h._id)}>Delete</button>
+                                                    </td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
                             </div>
                         )}
 

--- a/frontend/src/pages/HostelManagement/OwnerDashboard.css
+++ b/frontend/src/pages/HostelManagement/OwnerDashboard.css
@@ -1,27 +1,34 @@
 .owner-dashboard-container {
     display: flex;
-    padding-top: 90px;
+    width: 100%;
+    padding-top: 80px;
     /* Space for fixed navbar */
-    min-height: calc(100vh - 90px);
+    min-height: 100vh;
     background-color: #060a1f;
     color: #fff;
     font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    overflow-x: hidden;
 }
 
 /* ===== SIDEBAR ===== */
 .od-sidebar {
-    width: 260px;
-    background: #0a0f28;
+    width: 280px;
+    background: rgba(10, 15, 40, 0.8);
+    backdrop-filter: blur(10px);
     border-right: 1px solid rgba(255, 255, 255, 0.05);
     display: flex;
     flex-direction: column;
-    padding: 24px 0;
+    padding: 32px 0;
+    position: sticky;
+    top: 80px;
+    height: calc(100vh - 80px);
+    flex-shrink: 0;
 }
 
 .sidebar-header {
     padding: 0 24px 24px;
-    border-bottom: 1px solid #f1f5f9;
-    margin-bottom: 16px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    margin-bottom: 24px;
 }
 
 .sidebar-header h3 {
@@ -72,8 +79,9 @@
 /* ===== MAIN CONTENT ===== */
 .od-main-content {
     flex: 1;
-    padding: 32px 40px;
+    padding: 40px;
     overflow-y: auto;
+    width: 100%;
 }
 
 .owner-header {
@@ -118,27 +126,38 @@
 }
 
 .stat-card {
-    background: #0d122b;
-    padding: 24px;
-    border-radius: 12px;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-    border: 1px solid rgba(255, 255, 255, 0.07);
-    text-align: center;
+    background: rgba(13, 18, 43, 0.5);
+    backdrop-filter: blur(5px);
+    padding: 32px;
+    border-radius: 16px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    text-align: left;
+    transition: transform 0.3s ease;
+}
+
+.stat-card:hover {
+    transform: translateY(-5px);
+    border-color: rgba(16, 185, 129, 0.3);
 }
 
 .stat-card h4 {
     margin: 0 0 12px 0;
-    font-size: 0.9rem;
-    color: rgba(255, 255, 255, 0.4);
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.5);
     text-transform: uppercase;
-    letter-spacing: 0.025em;
+    letter-spacing: 0.1em;
+    font-weight: 600;
 }
 
 .stat-number {
     margin: 0;
-    font-size: 2rem;
-    font-weight: 700;
+    font-size: 2.5rem;
+    font-weight: 800;
     color: #fff;
+    background: linear-gradient(135deg, #fff 0%, #a5b4fc 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
 }
 
 /* ===== NEW COMPLEX FORM STYLES ===== */
@@ -593,17 +612,19 @@
 
 .no-hostels {
     text-align: center;
-    padding: 60px;
-    background: #f8fafc;
-    border-radius: 16px;
-    color: #94a3b8;
-    border: 2px dashed #e2e8f0;
+    padding: 80px 40px;
+    background: rgba(13, 18, 43, 0.3);
+    border-radius: 20px;
+    color: rgba(255, 255, 255, 0.4);
+    border: 2px dashed rgba(255, 255, 255, 0.05);
+    font-size: 1.1rem;
 }
 
 /* ===== RESPONSIVE ===== */
 @media (max-width: 1024px) {
     .od-sidebar {
         width: 80px;
+        padding: 24px 0;
     }
 
     .nav-item span:not(.icon) {
@@ -618,41 +639,124 @@
 @media (max-width: 768px) {
     .owner-dashboard-container {
         flex-direction: column;
+        padding-top: 70px; /* Reduced padding for mobile */
     }
 
     .od-sidebar {
         width: 100%;
+        height: auto;
+        min-height: unset;
+        position: sticky;
+        top: 70px; /* Stay below navbar */
+        z-index: 100;
         border-right: none;
-        border-bottom: 1px solid #e2e8f0;
-        padding: 12px 0;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        padding: 8px 0;
+        background: rgba(10, 15, 40, 0.95);
+    }
+
+    .sidebar-header {
+        display: none; /* Hide header on mobile to save space */
     }
 
     .od-nav {
         flex-direction: row;
         overflow-x: auto;
-        padding: 0 12px;
+        padding: 0 16px;
+        gap: 8px;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none; /* Hide scrollbar for cleaner look */
+    }
+
+    .od-nav::-webkit-scrollbar {
+        display: none;
     }
 
     .nav-item {
+        padding: 10px 16px;
         white-space: nowrap;
+        font-size: 0.85rem;
+    }
+
+    .nav-item .icon {
+        font-size: 1rem;
+    }
+
+    .nav-item span:not(.icon) {
+        display: inline; /* Bring back labels on mobile horizontal nav */
     }
 
     .od-main-content {
-        padding: 20px;
+        padding: 20px 12px;
+        width: 100%;
+    }
+
+    .owner-form-card {
+        padding: 20px 16px;
+        border-radius: 12px;
+    }
+
+    .form-section {
+        padding: 16px;
+        gap: 20px;
     }
 
     .form-row-3 {
         grid-template-columns: 1fr;
+        gap: 12px;
     }
 
+    /* Rooms Management Mobile */
     .room-entry-row {
-        grid-template-columns: 1fr 1fr;
-        gap: 8px;
+        grid-template-columns: 1fr;
+        gap: 0;
+        padding: 12px;
+        position: relative;
+    }
+
+    .room-entry-row .form-group {
+        margin-bottom: 12px;
     }
 
     .btn-remove-room {
-        grid-column: span 2;
-        width: 100%;
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        width: 32px;
+        height: 32px;
         margin-bottom: 0;
+        background: rgba(239, 68, 68, 0.1);
+        border: 1px solid rgba(239, 68, 68, 0.2);
+    }
+
+    .checkbox-grid {
+        grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+        gap: 10px;
+    }
+
+    .image-previews-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .stats-grid {
+        grid-template-columns: 1fr; /* Stack stats on mobile */
+        gap: 16px;
+    }
+
+    .stat-card {
+        padding: 24px;
+    }
+
+    .hostel-grid-owner {
+        grid-template-columns: 1fr;
+    }
+
+    .form-footer-actions {
+        text-align: center;
+    }
+
+    .btn-submit-hostel {
+        width: 100%;
+        padding: 14px 20px;
     }
 }

--- a/frontend/src/pages/HostelManagement/OwnerDashboard.jsx
+++ b/frontend/src/pages/HostelManagement/OwnerDashboard.jsx
@@ -118,7 +118,6 @@ const OwnerDashboard = () => {
         const newPreviews = [...previews];
 
         files.forEach(file => {
-            // Find the first slot that doesn't have a file AND doesn't have an existing preview
             const firstEmpty = newPreviews.findIndex(p => p === null);
             if (firstEmpty !== -1) {
                 newImages[firstEmpty] = file;
@@ -169,10 +168,9 @@ const OwnerDashboard = () => {
                 parking: false
             },
             rooms: hostel.rooms && hostel.rooms.length > 0 ? hostel.rooms : [{ roomNo: '', totalBeds: '', availableBeds: '' }],
-            images: [null, null, null] // Reuse existing images logic or handle differently if needed
+            images: [null, null, null]
         });
         
-        // Show existing images in previews if available
         if (hostel.images && Array.isArray(hostel.images)) {
             const newPreviews = [null, null, null];
             hostel.images.forEach((img, idx) => {
@@ -210,7 +208,6 @@ const OwnerDashboard = () => {
             return false;
         }
         
-        // Check if there's at least one image (either a new File in form.images OR an existing URL/base64 in previews)
         const hasNewImage = form.images.some(img => img !== null);
         const hasExistingImage = previews.some(p => p !== null && (typeof p === 'string'));
         
@@ -243,16 +240,13 @@ const OwnerDashboard = () => {
         if (!validateForm()) return;
 
         try {
-            let imagesToUpload = [];
-            
-            // Handle images: if they are files (new), convert to base64. If strings (existing), keep as is.
             const imagePromises = form.images.map(async (img, idx) => {
                 if (img instanceof File) {
                     return await fileToBase64(img);
                 } else if (previews[idx] && typeof previews[idx] === 'string' && previews[idx].startsWith('http')) {
-                    return previews[idx]; // Keep existing URL
+                    return previews[idx];
                 } else if (previews[idx] && typeof previews[idx] === 'string' && previews[idx].startsWith('data:image')) {
-                    return previews[idx]; // Keep already converted base64 if any
+                    return previews[idx];
                 }
                 return null;
             });
@@ -293,7 +287,6 @@ const OwnerDashboard = () => {
                     setSuccessMsg('Hostel submitted successfully! It will appear after admin approval.');
                 }
                 
-                // Reset form
                 setForm({
                     name: '', location: '', description: '', price: '', contact: '',
                     gender: 'mixed',
@@ -311,6 +304,31 @@ const OwnerDashboard = () => {
             }
         } catch (err) {
             setError('Could not connect to server. Make sure the backend is running.');
+        }
+    };
+
+    const handleDelete = async (id) => {
+        if (!window.confirm('Are you sure you want to delete this listing? This action cannot be undone.')) return;
+        
+        setError('');
+        setSuccessMsg('');
+        
+        try {
+            const res = await fetch(`http://localhost:5000/api/hostel/${id}`, {
+                method: 'DELETE',
+                headers: { 'Authorization': `Bearer ${token}` }
+            });
+            const data = await res.json();
+            
+            if (res.ok) {
+                setHostels(prev => prev.filter(h => (h._id !== id && h.id !== id)));
+                setSuccessMsg('Hostel removed successfully.');
+                setTimeout(() => setSuccessMsg(''), 3000);
+            } else {
+                setError(data.message || 'Failed to delete hostel.');
+            }
+        } catch (err) {
+            setError('Could not connect to server.');
         }
     };
 
@@ -345,178 +363,178 @@ const OwnerDashboard = () => {
                 </nav>
             </aside>
 
-            <main className="od-main">
-                    {activeTab === 'overview' && (
-                        <div className="overview-section">
-                            <div className="stats-grid">
-                                <div className="stat-card">
-                                    <h4>Total Listings</h4>
-                                    <p className="stat-number">{hostels.length}</p>
-                                </div>
-                                <div className="stat-card">
-                                    <h4>Verification Status</h4>
-                                    <p className="stat-number" style={{ fontSize: '1.2rem' }}>
-                                        {hostels.filter(h => h.status === 'approved').length} Approved
-                                    </p>
-                                </div>
+            <main className="od-main-content">
+                {activeTab === 'overview' && (
+                    <div className="overview-section">
+                        <div className="stats-grid">
+                            <div className="stat-card">
+                                <h4>Total Listings</h4>
+                                <p className="stat-number">{hostels.length}</p>
+                            </div>
+                            <div className="stat-card">
+                                <h4>Verification Status</h4>
+                                <p className="stat-number" style={{ fontSize: '1.2rem' }}>
+                                    {hostels.filter(h => h.status === 'approved').length} Approved
+                                </p>
                             </div>
                         </div>
-                    )}
+                    </div>
+                )}
 
-                    {activeTab === 'add' && (
-                        <div className="owner-form-card">
-                            <div className="form-header-flex">
-                                <h3>{isEditing ? 'Edit Hostel / Boarding' : 'Add New Hostel / Boarding'}</h3>
-                                {isEditing && <button className="btn-cancel-edit" onClick={cancelEdit}>Cancel Edit</button>}
-                            </div>
-                            {error && <div className="form-error-banner">⚠️ {error}</div>}
-                            {successMsg && <div className="form-success-banner">✅ {successMsg}</div>}
-                            <form onSubmit={handleSubmit} className="hostel-form-complex">
-                                <section className="form-section">
-                                    <h4>Basic Information</h4>
+                {activeTab === 'add' && (
+                    <div className="owner-form-card">
+                        <div className="form-header-flex">
+                            <h3>{isEditing ? 'Edit Hostel / Boarding' : 'Add New Hostel / Boarding'}</h3>
+                            {isEditing && <button className="btn-cancel-edit" onClick={cancelEdit}>Cancel Edit</button>}
+                        </div>
+                        {error && <div className="form-error-banner">⚠️ {error}</div>}
+                        {successMsg && <div className="form-success-banner">✅ {successMsg}</div>}
+                        <form onSubmit={handleSubmit} className="hostel-form-complex">
+                            <section className="form-section">
+                                <h4>Basic Information</h4>
+                                <div className="form-group">
+                                    <label>Hostel Name / Title *</label>
+                                    <input name="name" value={form.name} onChange={handleChange} required placeholder="e.g. Sunshine Boys Hostel" />
+                                </div>
+                                <div className="form-row-3">
                                     <div className="form-group">
-                                        <label>Hostel Name / Title *</label>
-                                        <input name="name" value={form.name} onChange={handleChange} required placeholder="e.g. Sunshine Boys Hostel" />
+                                        <label>Monthly Price (Rs.) *</label>
+                                        <input name="price" type="number" value={form.price} onChange={handleChange} required placeholder="5000" />
                                     </div>
-                                    <div className="form-row-3">
-                                        <div className="form-group">
-                                            <label>Monthly Price (Rs.) *</label>
-                                            <input name="price" type="number" value={form.price} onChange={handleChange} required placeholder="5000" />
-                                        </div>
-                                        <div className="form-group">
-                                            <label>Location / Area *</label>
-                                            <input name="location" value={form.location} onChange={handleChange} required placeholder="e.g. Malabe" />
-                                        </div>
-                                        <div className="form-group">
-                                            <label>Contact Number *</label>
-                                            <input name="contact" value={form.contact} onChange={handleChange} onBlur={handleContactBlur} required placeholder="0712345678" />
-                                        </div>
+                                    <div className="form-group">
+                                        <label>Location / Area *</label>
+                                        <input name="location" value={form.location} onChange={handleChange} required placeholder="e.g. Malabe" />
                                     </div>
-                                </section>
+                                    <div className="form-group">
+                                        <label>Contact Number *</label>
+                                        <input name="contact" value={form.contact} onChange={handleChange} onBlur={handleContactBlur} required placeholder="0712345678" />
+                                    </div>
+                                </div>
+                            </section>
 
-                                <section className="form-section">
-                                    <h4>Preferences & Facilities</h4>
-                                    <div className="form-group">
-                                        <label>Gender Allowed</label>
-                                        <div className="radio-group">
-                                            <label><input type="radio" name="gender" value="boys" checked={form.gender === 'boys'} onChange={handleChange} /> Boys</label>
-                                            <label><input type="radio" name="gender" value="girls" checked={form.gender === 'girls'} onChange={handleChange} /> Girls</label>
-                                            <label><input type="radio" name="gender" value="mixed" checked={form.gender === 'mixed'} onChange={handleChange} /> Mixed</label>
-                                        </div>
+                            <section className="form-section">
+                                <h4>Preferences & Facilities</h4>
+                                <div className="form-group">
+                                    <label>Gender Allowed</label>
+                                    <div className="radio-group">
+                                        <label><input type="radio" name="gender" value="boys" checked={form.gender === 'boys'} onChange={handleChange} /> Boys</label>
+                                        <label><input type="radio" name="gender" value="girls" checked={form.gender === 'girls'} onChange={handleChange} /> Girls</label>
+                                        <label><input type="radio" name="gender" value="mixed" checked={form.gender === 'mixed'} onChange={handleChange} /> Mixed</label>
                                     </div>
-                                    <div className="form-group">
-                                        <label>Facilities Offered</label>
-                                        <div className="checkbox-grid">
-                                            {Object.keys(form.facilities).map(f => (
-                                                <label key={f} className="checkbox-item">
-                                                    <input type="checkbox" name={f} checked={form.facilities[f]} onChange={handleFacilityChange} />
-                                                    {f.charAt(0).toUpperCase() + f.slice(1)}
-                                                </label>
+                                </div>
+                                <div className="form-group">
+                                    <label>Facilities Offered</label>
+                                    <div className="checkbox-grid">
+                                        {Object.keys(form.facilities).map(f => (
+                                            <label key={f} className="checkbox-item">
+                                                <input type="checkbox" name={f} checked={form.facilities[f]} onChange={handleFacilityChange} />
+                                                {f.charAt(0).toUpperCase() + f.slice(1)}
+                                            </label>
+                                        ))}
+                                    </div>
+                                </div>
+                            </section>
+
+                            <section className="form-section">
+                                <h4>Rooms Management</h4>
+                                <div className="rooms-list">
+                                    {form.rooms.map((room, index) => (
+                                        <div key={index} className="room-entry-row">
+                                            <div className="form-group">
+                                                <label>Room No</label>
+                                                <input value={room.roomNo} onChange={(e) => handleRoomChange(index, 'roomNo', e.target.value)} placeholder="A-01" />
+                                            </div>
+                                            <div className="form-group">
+                                                <label>Total Beds</label>
+                                                <input type="number" value={room.totalBeds} onChange={(e) => handleRoomChange(index, 'totalBeds', e.target.value)} placeholder="4" />
+                                            </div>
+                                            <div className="form-group">
+                                                <label>Available Beds</label>
+                                                <input type="number" value={room.availableBeds} onChange={(e) => handleRoomChange(index, 'availableBeds', e.target.value)} placeholder="2" />
+                                            </div>
+                                            {form.rooms.length > 1 && (
+                                                <button type="button" className="btn-remove-room" onClick={() => removeRoom(index)}>×</button>
+                                            )}
+                                        </div>
+                                    ))}
+                                </div>
+                                <button type="button" className="btn-add-room" onClick={addRoom}>+ Add Another Room</button>
+                            </section>
+
+                            <section className="form-section">
+                                <h4>Photos & Description</h4>
+                                <div className="form-group">
+                                    <label>Hostel Photos (Up to 3) *</label>
+                                    <div className="image-upload-wrapper">
+                                        <label className="upload-dropzone">
+                                            <input
+                                                type="file"
+                                                multiple
+                                                accept="image/*"
+                                                onChange={handleFileChange}
+                                                disabled={form.images.filter(img => img !== null).length >= 3}
+                                                hidden
+                                            />
+                                            <div className="upload-hint">
+                                                <span className="upload-icon">📸</span>
+                                                <span>Click to upload photos</span>
+                                            </div>
+                                        </label>
+                                        <div className="image-previews-grid">
+                                            {previews.map((src, idx) => src && (
+                                                <div key={idx} className="preview-item">
+                                                    <img src={src} alt={`preview-${idx}`} />
+                                                    <button type="button" className="btn-remove-img" onClick={() => removeImage(idx)}>×</button>
+                                                </div>
                                             ))}
                                         </div>
                                     </div>
-                                </section>
+                                </div>
+                                <div className="form-group">
+                                    <label>Description & Rules</label>
+                                    <textarea name="description" value={form.description} onChange={handleChange} placeholder="Describe your hostel, rules, entry times, etc." />
+                                </div>
+                            </section>
 
-                                <section className="form-section">
-                                    <h4>Rooms Management</h4>
-                                    <div className="rooms-list">
-                                        {form.rooms.map((room, index) => (
-                                            <div key={index} className="room-entry-row">
-                                                <div className="form-group">
-                                                    <label>Room No</label>
-                                                    <input value={room.roomNo} onChange={(e) => handleRoomChange(index, 'roomNo', e.target.value)} placeholder="A-01" />
-                                                </div>
-                                                <div className="form-group">
-                                                    <label>Total Beds</label>
-                                                    <input type="number" value={room.totalBeds} onChange={(e) => handleRoomChange(index, 'totalBeds', e.target.value)} placeholder="4" />
-                                                </div>
-                                                <div className="form-group">
-                                                    <label>Available Beds</label>
-                                                    <input type="number" value={room.availableBeds} onChange={(e) => handleRoomChange(index, 'availableBeds', e.target.value)} placeholder="2" />
-                                                </div>
-                                                {form.rooms.length > 1 && (
-                                                    <button type="button" className="btn-remove-room" onClick={() => removeRoom(index)}>×</button>
-                                                )}
+                            <div className="form-footer-actions">
+                                <p className="approval-notice">Listing will be visible after <strong>Admin Approval</strong>.</p>
+                                <button type="submit" className="btn-submit-hostel">
+                                    {isEditing ? 'Update Hostel' : 'Submit for Approval'}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                )}
+
+                {activeTab === 'list' && (
+                    <div className="owner-list">
+                        <h3>Your Hostels</h3>
+                        {!token && <div className="form-error-banner">⚠️ Please <a href="/login">login</a> to view your listings.</div>}
+                        {loading ? <div className="loader"></div> : (
+                            hostels.length > 0 ? (
+                                <div className="hostel-grid-owner">
+                                    {hostels.map(h => (
+                                        <div className="hostel-item-card" key={h._id || h.id}>
+                                            <div className="card-badge-status" data-status={h.status || 'pending'}>
+                                                {h.status || 'Pending'}
                                             </div>
-                                        ))}
-                                    </div>
-                                    <button type="button" className="btn-add-room" onClick={addRoom}>+ Add Another Room</button>
-                                </section>
-
-                                <section className="form-section">
-                                    <h4>Photos & Description</h4>
-                                    <div className="form-group">
-                                        <label>Hostel Photos (Up to 3) *</label>
-                                        <div className="image-upload-wrapper">
-                                            <label className="upload-dropzone">
-                                                <input
-                                                    type="file"
-                                                    multiple
-                                                    accept="image/*"
-                                                    onChange={handleFileChange}
-                                                    disabled={form.images.filter(img => img !== null).length >= 3}
-                                                    hidden
-                                                />
-                                                <div className="upload-hint">
-                                                    <span className="upload-icon">📸</span>
-                                                    <span>Click to upload photos</span>
+                                            <img src={h.images?.[0] || h.image || 'https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=400&q=60'} alt={h.name} />
+                                            <div className="hostel-meta">
+                                                <h4>{h.name}</h4>
+                                                <p className="loc">📍 {h.location}</p>
+                                                <p className="price">Rs. {h.price || '—'}</p>
+                                                <div className="card-actions">
+                                                    <button className="btn-edit-sm" onClick={() => handleEdit(h)}>Edit</button>
+                                                    <button className="btn-delete-sm" onClick={() => handleDelete(h._id || h.id)}>Delete</button>
                                                 </div>
-                                            </label>
-                                            <div className="image-previews-grid">
-                                                {previews.map((src, idx) => src && (
-                                                    <div key={idx} className="preview-item">
-                                                        <img src={src} alt={`preview-${idx}`} />
-                                                        <button type="button" className="btn-remove-img" onClick={() => removeImage(idx)}>×</button>
-                                                    </div>
-                                                ))}
                                             </div>
                                         </div>
-                                    </div>
-                                    <div className="form-group">
-                                        <label>Description & Rules</label>
-                                        <textarea name="description" value={form.description} onChange={handleChange} placeholder="Describe your hostel, rules, entry times, etc." />
-                                    </div>
-                                </section>
-
-                                <div className="form-footer-actions">
-                                    <p className="approval-notice">Listing will be visible after <strong>Admin Approval</strong>.</p>
-                                    <button type="submit" className="btn-submit-hostel">
-                                        {isEditing ? 'Update Hostel' : 'Submit for Approval'}
-                                    </button>
+                                    ))}
                                 </div>
-                            </form>
-                        </div>
-                    )}
-
-                    {activeTab === 'list' && (
-                        <div className="owner-list">
-                            <h3>Your Hostels</h3>
-                            {!token && <div className="form-error-banner">⚠️ Please <a href="/login">login</a> to view your listings.</div>}
-                            {loading ? <div className="loader"></div> : (
-                                hostels.length > 0 ? (
-                                    <div className="hostel-grid-owner">
-                                        {hostels.map(h => (
-                                            <div className="hostel-item-card" key={h._id || h.id}>
-                                                <div className="card-badge-status" data-status={h.status || 'pending'}>
-                                                    {h.status || 'Pending'}
-                                                </div>
-                                                <img src={h.images?.[0] || h.image || 'https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=400&q=60'} alt={h.name} />
-                                                <div className="hostel-meta">
-                                                    <h4>{h.name}</h4>
-                                                    <p className="loc">📍 {h.location}</p>
-                                                    <p className="price">Rs. {h.price || '—'}</p>
-                                                    <div className="card-actions">
-                                                        <button className="btn-edit-sm" onClick={() => handleEdit(h)}>Edit</button>
-                                                        <button className="btn-delete-sm">Delete</button>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        ))}
-                                    </div>
-                                ) : <div className="no-hostels">No hostels yet. Click 'Add New' to begin.</div>
-                            )}
-                        </div>
-                    )}
+                            ) : <div className="no-hostels">No hostels yet. Click 'Add New' to begin.</div>
+                        )}
+                    </div>
+                )}
             </main>
         </div>
     );


### PR DESCRIPTION
Large visual and layout overhaul for the OwnerDashboard: adjust container sizing and paddings, set min-height to 100vh, hide horizontal overflow, and tighten typography. Revamped sidebar with wider width, translucent background/backdrop blur, sticky positioning, increased padding and height constraints. Restyled stat cards with softer glass effect, hover lift, stronger numeric typographic treatment and gradient text. Numerous responsive/mobile improvements: collapse sidebar to top horizontal nav, hide sidebar header, tune paddings, stack grids (rooms, stats, hostels), simplify room rows, and improve touch scrolling. Also updated JSX to use the renamed main class (od-main -> od-main-content) to match the CSS changes.