### PR TITLE
refactor: update search functionality to filter hostels by name only

### DIFF
--- a/frontend/src/pages/HostelManagement/HostelManagement.jsx
+++ b/frontend/src/pages/HostelManagement/HostelManagement.jsx
@@ -33,8 +33,7 @@ const HostelManagement = () => {
     }, []);
 
     const filtered = hostels.filter(h => {
-        const matchesSearch = h.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-            h.location?.toLowerCase().includes(searchTerm.toLowerCase());
+        const matchesSearch = h.name?.toLowerCase().startsWith(searchTerm.toLowerCase());
         const matchesFilter = filter === 'all' || (h.gender?.toLowerCase() === filter);
         return matchesSearch && matchesFilter;
     });
@@ -73,7 +72,7 @@ const HostelManagement = () => {
                 <div className="search-box">
                     <input
                         type="text"
-                        placeholder="Search by name or location..."
+                        placeholder="Search by hostel name..."
                         value={searchTerm}
                         onChange={(e) => setSearchTerm(e.target.value)}
                     />

--- a/frontend/src/pages/HostelManagement/HostelServices.jsx
+++ b/frontend/src/pages/HostelManagement/HostelServices.jsx
@@ -49,8 +49,7 @@ const HostelServices = () => {
     ];
 
     const filteredHostels = hostels.filter(hostel =>
-        hostel.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        hostel.address.toLowerCase().includes(searchTerm.toLowerCase())
+        hostel.name.toLowerCase().startsWith(searchTerm.toLowerCase())
     );
 
     return (
@@ -72,7 +71,7 @@ const HostelServices = () => {
                 <div className="search-box">
                     <input
                         type="text"
-                        placeholder="Search by name or location..."
+                        placeholder="Search by hostel name..."
                         value={searchTerm}
                         onChange={(e) => setSearchTerm(e.target.value)}
                     />


### PR DESCRIPTION
This pull request updates the search functionality in the hostel management and services pages to only match hostel names that start with the entered search term, rather than matching anywhere in the name or location/address. The placeholder text in the search input fields has also been updated to reflect this narrower search scope.

**Search functionality changes:**

* The search filter in `HostelManagement.jsx` now only matches hostels where the name starts with the search term, instead of matching anywhere in the name or location.
* The search filter in `HostelServices.jsx` now only matches hostels where the name starts with the search term, instead of matching anywhere in the name or address.

**UI/UX improvements:**

* The placeholder text in the search input of `HostelManagement.jsx` has been updated to "Search by hostel name..." to clarify the search behavior.
* The placeholder text in the search input of `HostelServices.jsx` has been updated to "Search by hostel name..." to clarify the search behavior.